### PR TITLE
Fixing a bug that makes the basic example break

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -33,7 +33,7 @@ var linksG = svg.append("g")
 var nodesG = svg.append("g")
   .attr("class", "nodes");
 
-var color = d3.scaleOrdinal(d3.schemeCategory20);
+var color = d3.scaleOrdinal(d3.schemeCategory10);
 
 var simulation = d3.forceSimulation()
   .force("link", d3.forceLink().id(function(d) { return d.id; }))


### PR DESCRIPTION
Changed d3.schemeCategory20 to d3.schemeCategory10 (Since Category20 no longer exists in the d3-scale-chromatic)