### PR TITLE
Extract attribute definition and typing into src/attribs.js (#67)

### DIFF
--- a/src/attribs.js
+++ b/src/attribs.js
@@ -1,0 +1,426 @@
+import * as d3 from "d3";
+import { scaleText, scaleOrdered } from "./scales.js";
+import { getAttribsFromObjectAsFn } from "./utils.js";
+
+/**
+ * How a column becomes an attribute: declaring one with a scale, guessing the
+ * type of every column in the data, and switching a column from one type to
+ * another afterwards.
+ *
+ * Second slice extracted from src/navio.js for issue #67 - see
+ * docs/ai/2026-08-20-navio-decomposition-design.md for the mechanism and, in
+ * particular, section 11 for the measurement mistakes that are easy to repeat.
+ *
+ * This module registers thirteen public methods on `nv` and is otherwise
+ * read-only: it never writes to any binding it is given, which is why `ctx`
+ * here is all getters and no setters. It reads five bindings from navio.js's
+ * closure - `data`, `attribsOrdered`, `dAttribs`, `colScales` and `nv` -
+ * and every one of them is REASSIGNED elsewhere in navio.js, so all five must
+ * cross as getters or the module would go on reading a replaced array.
+ *
+ * @param {object} ctx - { nv, get data(), get attribsOrdered(), get dAttribs(),
+ *   get colScales(), attribAt, getAttrib, getAttribName, moveAttrToPos,
+ *   findNotNull }
+ */
+export function createAttribs(ctx) {
+  /**
+   * Is this attribute actually present in the data?
+   *
+   * Checks a sample rather than every row: a column can legitimately be null
+   * in the first few records without being absent. Returns true when there is
+   * no data yet - the caller is allowed to declare attributes first.
+   */
+  function attribExistsInData(attr) {
+    if (!ctx.data.length) return true;
+    const name = ctx.getAttribName(attr);
+    // Derived columns are not row properties. See #88.
+    if (name === "__seqId" || name === "selected") return true;
+    if (typeof attr === "function") return true; // an accessor computes its own
+    const sample = Math.min(
+      ctx.data.length,
+      ctx.nv.howManyItemsShouldSearchForNotNull
+    );
+    for (let i = 0; i < sample; i++) {
+      if (ctx.data[i] != null && name in ctx.data[i]) return true;
+    }
+    return false;
+  }
+
+  ctx.nv.addAttrib = function (attr, scale) {
+    if (scale === undefined) {
+      scale = d3.scaleOrdinal(d3.schemeCategory10);
+    }
+    if (ctx.dAttribs.has(ctx.getAttribName(attr))) {
+      console.warn(`navio.addAttrib: attribute ${attr} already added`);
+      return;
+    }
+    // A misspelled column used to be added silently and drawn as a stripe of
+    // nulls, which looks like a data problem rather than a typo.
+    if (!attribExistsInData(attr)) {
+      const known = Object.keys(ctx.data[0] || {});
+      console.warn(
+        `navio.addAttrib: "${ctx.getAttribName(attr)}" is not in the data. ` +
+          `The column will be empty. Available: ${known.join(", ")}`
+      );
+    }
+    ctx.attribsOrdered.push(attr);
+    ctx.dAttribs.set(ctx.getAttribName(attr), attr);
+    ctx.colScales.set(attr, scale);
+    return ctx.nv;
+  };
+
+  ctx.nv.addSequentialAttrib = function (attr, _scale) {
+    const domain =
+      ctx.data !== undefined && ctx.data.length > 0
+        ? // By INDEX, not by row: "__seqId" is derived (#88), so reading it off
+          // the row gives undefined for every row and collapses the domain to
+          // [undefined, undefined] - a flat, unreadable column.
+          d3.extent(ctx.data, function (_d, i) {
+            return ctx.attribAt(i, attr);
+          })
+        : [0, 1]; //if we don"t have data, set the default domain
+    const scale =
+      _scale ||
+      d3.scaleSequential(ctx.nv.defaultColorInterpolator).domain(domain);
+    scale.__type = "seq";
+    ctx.nv.addAttrib(attr, scale);
+    return ctx.nv;
+  };
+
+  // Same as addSequentialAttrib but with a different color
+  ctx.nv.addDateAttrib = function (attr, _scale) {
+    const domain =
+      ctx.data !== undefined && ctx.data.length > 0
+        ? d3.extent(ctx.data, function (d) {
+            return ctx.getAttrib(d, attr);
+          })
+        : [0, 1];
+
+    const scale =
+      _scale ||
+      d3.scaleSequential(ctx.nv.defaultColorInterpolatorDate).domain(domain); //if we don"t have data, set the default domain
+    ctx.nv.addAttrib(attr, scale);
+
+    scale.__type = "date";
+    return ctx.nv;
+  };
+
+  // Adds a diverging scale
+  ctx.nv.addDivergingAttrib = function (attr, _scale) {
+    const domain =
+      ctx.data !== undefined && ctx.data.length > 0
+        ? d3.extent(ctx.data, function (d) {
+            return ctx.getAttrib(d, attr);
+          })
+        : [-1, 1];
+    const scale =
+      _scale ||
+      d3
+        .scaleSequential(ctx.nv.defaultColorInterpolatorDiverging)
+        .domain([domain[0], domain[1]]); //if we don"t have data, set the default domain
+    scale.__type = "div";
+    ctx.nv.addAttrib(attr, scale);
+    return ctx.nv;
+  };
+
+  /**
+   * A palette is either an array or a function of the category count. The count
+   * is not known when the column is added - scaleOrdinal builds its domain
+   * lazily - so a function palette is resolved later, in updateColorDomains,
+   * and remembered here until then.
+   */
+  function categoricalRange(n) {
+    const p = ctx.nv.defaultColorCategorical;
+    return typeof p === "function" ? p(n) : p;
+  }
+
+  ctx.nv.addCategoricalAttrib = function (attr, _scale) {
+    // 10 is a starting range only; updateColorDomains sets the real one once it
+    // knows how many categories there are.
+    const scale = _scale || d3.scaleOrdinal(categoricalRange(10));
+    // Who owns the colours. updateColorDomains re-resolves the palette for the
+    // scales Navio made and leaves a caller's scale alone.
+    scale.__navioOwned = !_scale;
+    scale.__type = "cat";
+    ctx.nv.addAttrib(attr, scale);
+
+    return ctx.nv;
+  };
+
+  ctx.nv.addTextAttrib = function (attr, _scale) {
+    const scale =
+      _scale ||
+      scaleText(
+        ctx.nv.nullColor,
+        ctx.nv.digitsForText,
+        ctx.nv.defaultColorInterpolatorText
+      );
+
+    ctx.nv.addAttrib(attr, scale);
+
+    return ctx.nv;
+  };
+
+  ctx.nv.addOrderedAttrib = function (attr, _scale) {
+    const scale =
+      _scale ||
+      scaleOrdered(ctx.nv.nullColor, ctx.nv.defaultColorInterpolatorOrdered);
+
+    ctx.nv.addAttrib(attr, scale);
+
+    return ctx.nv;
+  };
+
+  ctx.nv.addBooleanAttrib = function (attr, _scale) {
+    const scale =
+      _scale ||
+      d3
+        .scaleOrdinal()
+        .domain([true, false, null])
+        .range(ctx.nv.defaultColorRangeBoolean);
+
+    scale.__type = "bool";
+    ctx.nv.addAttrib(attr, scale);
+
+    return ctx.nv;
+  };
+
+  // Adds a more complex attribute with a wrapper to convert it into JSON
+  ctx.nv.addObjectAttrib = function (attr, _scale) {
+    const scale =
+      _scale ||
+      scaleText(
+        ctx.nv.nullColor,
+        ctx.nv.digitsForObjects, // nv.digitsForText,
+        ctx.nv.defaultColorInterpolatorObject
+      );
+
+    let stringifiedAttr;
+    if (typeof attr === "function") {
+      stringifiedAttr = (d) => JSON.stringify(attr(d));
+    } else {
+      stringifiedAttr = (d) => {
+        try {
+          return d[attr] ? JSON.stringify(d[attr]) : d[attr];
+        } catch (_e) {
+          return undefined;
+        }
+      };
+      // Navio derives a column's label from fn.name (see getAttribName), so
+      // set it directly rather than baking the attribute name into evaluated
+      // source the way convertAttribToFn still does - that pattern lets a
+      // crafted key in user-supplied data execute arbitrary code (see #71).
+      Object.defineProperty(stringifiedAttr, "name", { value: String(attr) });
+    }
+    ctx.nv.addAttrib(stringifiedAttr, scale);
+    return ctx.nv;
+  };
+
+  // Adds all the attributes on the data, or all the attributes provided on the list based on their types
+  ctx.nv.addAllAttribs = function (_attribs) {
+    if (!ctx.data || !ctx.data.length)
+      throw Error(
+        "addAllAttribs called without data to guess the attribs. Make sure to call it after setting the data"
+      );
+
+    let attribs =
+      _attribs !== undefined
+        ? _attribs
+        : getAttribsFromObjectAsFn(
+            ctx.data[0],
+            ctx.nv.addAllAttribsRecursionLevel
+          );
+    // Attributes we skip are reported once at the end rather than one console
+    // line per column, so the message stays readable on wide datasets.
+    const skippedArrays = [],
+      skippedObjects = [];
+
+    for (let attr of attribs) {
+      if (attr === "__seqId" || attr === "__i" || attr === "selected") continue;
+
+      const attrName = typeof attr === "function" ? attr.name : attr;
+      const firstNotNull = ctx.findNotNull(ctx.data, attr);
+
+      if (
+        firstNotNull === null ||
+        firstNotNull === undefined ||
+        typeof firstNotNull === typeof ""
+      ) {
+        const numDistinctValues = new Set(
+          ctx.data
+            .slice(0, ctx.nv.howManyItemsShouldSearchForNotNull)
+            .map((d) => ctx.getAttrib(d, attr))
+        ).size;
+
+        // How many different elements are there
+        if (numDistinctValues < ctx.nv.maxNumDistinctForCategorical) {
+          ctx.nv.DEBUG &&
+            console.log(
+              `Navio: Adding attr ${attrName} as categorical with ${numDistinctValues} categories`
+            );
+          ctx.nv.addCategoricalAttrib(attr);
+        } else if (numDistinctValues < ctx.nv.maxNumDistinctForOrdered) {
+          ctx.nv.addOrderedAttrib(attr);
+          ctx.nv.DEBUG &&
+            console.log(
+              `Navio: Attr ${attrName} has more than ${ctx.nv.maxNumDistinctForCategorical} distinct values (${numDistinctValues}) using orderedAttrib`
+            );
+        } else {
+          ctx.nv.DEBUG &&
+            console.log(
+              `Navio: Attr ${attrName} has more than ${ctx.nv.maxNumDistinctForOrdered} distinct values (${numDistinctValues}) using textAttrib`
+            );
+          ctx.nv.addTextAttrib(attr);
+        }
+      } else if (typeof firstNotNull === typeof 0) {
+        // Numbers.
+        //
+        // Diverging only when the values actually STRADDLE the diverging point.
+        // updateColorDomains builds a diverging domain as [-absMax, absMax]
+        // around zero - "Assumes diverging point on 0" - so a column that never
+        // crosses zero gets a domain about twice its own magnitude with every
+        // value crammed into one end of the ramp. A negative minimum alone used
+        // to be enough, which is how citibike's start_lng (-74.02564 ..
+        // -73.886312) drew as one flat brown: its 0.139 of range sat inside a
+        // 148.05-wide domain, 0.094% of the scale.
+        const [numMin, numMax] = d3.extent(ctx.data, (d) =>
+          ctx.getAttrib(d, attr)
+        );
+        if (numMin < 0 && numMax > 0) {
+          ctx.nv.DEBUG &&
+            console.log(`Navio: Adding attr ${attrName} as diverging`);
+          ctx.nv.addDivergingAttrib(attr);
+        } else {
+          ctx.nv.DEBUG &&
+            console.log(`Navio: Adding attr ${attrName} as sequential`);
+          ctx.nv.addSequentialAttrib(attr);
+        }
+      } else if (firstNotNull instanceof Date) {
+        ctx.nv.DEBUG && console.log(`Navio: Adding attr ${attrName} as date`);
+        ctx.nv.addDateAttrib(attr);
+      } else if (typeof firstNotNull === typeof true) {
+        ctx.nv.DEBUG &&
+          console.log(`Navio: Adding attr ${attrName} as boolean`);
+        ctx.nv.addBooleanAttrib(attr);
+      } else {
+        // Default categories
+
+        if (Array.isArray(firstNotNull)) {
+          if (ctx.nv.addAllAttribsIncludeArrays) {
+            ctx.nv.DEBUG &&
+              console.log(
+                `Navio: Adding ${attrName} adding as Object (type=array)`
+              );
+            // nv.addCategoricalAttrib(attr);
+            ctx.nv.addObjectAttrib(attr);
+          } else {
+            skippedArrays.push(attrName);
+          }
+        } else {
+          if (ctx.nv.addAllAttribsIncludeObjects) {
+            ctx.nv.DEBUG &&
+              console.log(
+                `Navio: Adding object ${attrName} adding as Object (type=object)`
+              );
+            // nv.addCategoricalAttrib(attr);
+            ctx.nv.addObjectAttrib(attr);
+          } else {
+            skippedObjects.push(attrName);
+          }
+        }
+      }
+    }
+
+    // Skipping data silently would hide columns the caller expects to see, so
+    // this warns unconditionally - but only once, and it says how to opt in.
+    if (skippedArrays.length)
+      console.warn(
+        `navio.addAllAttribs: ignored ${skippedArrays.length} array attribute(s) [${skippedArrays.join(", ")}]. Set nv.addAllAttribsIncludeArrays = true to include them.`
+      );
+    if (skippedObjects.length)
+      console.warn(
+        `navio.addAllAttribs: ignored ${skippedObjects.length} object attribute(s) [${skippedObjects.join(", ")}]. Set nv.addAllAttribsIncludeObjects = true to include them.`
+      );
+
+    ctx.nv.data(ctx.data);
+    // drawBrushes(true); // updates brushes width
+    return ctx.nv;
+  };
+
+  // The attribute types a column can be switched between, and the method that
+  // builds each one's scale. "object" is excluded on purpose: addObjectAttrib
+  // replaces the attribute with a stringifying accessor rather than just
+  // changing its scale, so it is not a like-for-like swap.
+  const ATTRIB_TYPES = {
+    cat: { label: "categorical", add: "addCategoricalAttrib" },
+    seq: { label: "sequential", add: "addSequentialAttrib" },
+    ordered: { label: "ordered", add: "addOrderedAttrib" },
+    text: { label: "text", add: "addTextAttrib" },
+    date: { label: "date", add: "addDateAttrib" },
+    div: { label: "diverging", add: "addDivergingAttrib" },
+    bool: { label: "boolean", add: "addBooleanAttrib" },
+  };
+
+  /** The type tag of an attribute's colour scale: "cat", "seq", "text"... */
+  ctx.nv.getAttribType = function (attrib) {
+    const scale =
+      ctx.colScales.get(attrib) || ctx.colScales.get(ctx.getAttribName(attrib));
+    return scale && scale.__type;
+  };
+
+  /** The switchable types, as {value, label} - for building a picker. */
+  ctx.nv.getAttribTypes = function () {
+    return Object.entries(ATTRIB_TYPES).map(([value, t]) => ({
+      value,
+      label: t.label,
+    }));
+  };
+
+  /**
+   * Re-type a column: how it is coloured and how its values are interpreted.
+   *
+   * Only the colour scale changes. The attribute keeps its name, its position,
+   * and anything pointing at it - sorting compares raw values and so does a
+   * value filter, while a range filter compares positions, so none of them are
+   * invalidated by a re-type. addAllAttribs guesses types from the data and
+   * sometimes guesses wrong; this is the correction.
+   */
+  ctx.nv.setAttribType = function (attrib, type) {
+    const spec = ATTRIB_TYPES[type];
+    if (!spec) {
+      console.warn(
+        `navio.setAttribType: unknown type "${type}". ` +
+          `One of: ${Object.keys(ATTRIB_TYPES).join(", ")}`
+      );
+      return ctx.nv;
+    }
+    const name = ctx.getAttribName(attrib);
+    const pos = ctx.attribsOrdered.findIndex(
+      (a) => ctx.getAttribName(a) === name
+    );
+    if (pos === -1) {
+      console.warn(
+        `navio.setAttribType: "${name}" is not one of the attributes`
+      );
+      return ctx.nv;
+    }
+    const attr = ctx.attribsOrdered[pos];
+    if (ctx.nv.getAttribType(attr) === type) return ctx.nv;
+
+    // Drop it from all three structures and let the real add*Attrib rebuild
+    // it, so the scale is constructed exactly as it would have been at setup -
+    // domain included. Then put it back where it was: addAttrib appends.
+    ctx.attribsOrdered.splice(pos, 1);
+    ctx.dAttribs.delete(name);
+    ctx.colScales.delete(attr);
+    ctx.colScales.delete(name);
+
+    ctx.nv[spec.add](attr);
+    ctx.moveAttrToPos(attr, pos);
+
+    ctx.nv.hardUpdate();
+    return ctx.nv;
+  };
+
+  return { categoricalRange };
+}

--- a/src/navio.js
+++ b/src/navio.js
@@ -22,17 +22,13 @@ import {
   FilterByRangeNegative,
   filterFromValue,
 } from "./filters.js";
-import {
-  scaleText,
-  scaleOrdered,
-  d3AscendingNull,
-  d3DescendingNull,
-} from "./scales.js";
+import { d3AscendingNull, d3DescendingNull } from "./scales.js";
 import {
   getAttribsFromObjectRecursive,
   getAttribsFromObjectAsFn,
 } from "./utils.js";
 import { createSettingsPanel } from "./settings-panel.js";
+import { createAttribs } from "./attribs.js";
 
 let navioInstanceCount = 0;
 
@@ -3568,318 +3564,34 @@ function navio(selection, _h) {
     return nv;
   };
 
-  /**
-   * Is this attribute actually present in the data?
-   *
-   * Checks a sample rather than every row: a column can legitimately be null
-   * in the first few records without being absent. Returns true when there is
-   * no data yet - the caller is allowed to declare attributes first.
-   */
-  function attribExistsInData(attr) {
-    if (!data.length) return true;
-    const name = getAttribName(attr);
-    // Derived columns are not row properties. See #88.
-    if (name === "__seqId" || name === "selected") return true;
-    if (typeof attr === "function") return true; // an accessor computes its own
-    const sample = Math.min(data.length, nv.howManyItemsShouldSearchForNotNull);
-    for (let i = 0; i < sample; i++) {
-      if (data[i] != null && name in data[i]) return true;
-    }
-    return false;
-  }
-
-  nv.addAttrib = function (attr, scale) {
-    if (scale === undefined) {
-      scale = d3.scaleOrdinal(d3.schemeCategory10);
-    }
-    if (dAttribs.has(getAttribName(attr))) {
-      console.warn(`navio.addAttrib: attribute ${attr} already added`);
-      return;
-    }
-    // A misspelled column used to be added silently and drawn as a stripe of
-    // nulls, which looks like a data problem rather than a typo.
-    if (!attribExistsInData(attr)) {
-      const known = Object.keys(data[0] || {});
-      console.warn(
-        `navio.addAttrib: "${getAttribName(attr)}" is not in the data. ` +
-          `The column will be empty. Available: ${known.join(", ")}`
-      );
-    }
-    attribsOrdered.push(attr);
-    dAttribs.set(getAttribName(attr), attr);
-    colScales.set(attr, scale);
-    return nv;
-  };
-
-  nv.addSequentialAttrib = function (attr, _scale) {
-    const domain =
-      data !== undefined && data.length > 0
-        ? // By INDEX, not by row: "__seqId" is derived (#88), so reading it off
-          // the row gives undefined for every row and collapses the domain to
-          // [undefined, undefined] - a flat, unreadable column.
-          d3.extent(data, function (_d, i) {
-            return attribAt(i, attr);
-          })
-        : [0, 1]; //if we don"t have data, set the default domain
-    const scale =
-      _scale || d3.scaleSequential(nv.defaultColorInterpolator).domain(domain);
-    scale.__type = "seq";
-    nv.addAttrib(attr, scale);
-    return nv;
-  };
-
-  // Same as addSequentialAttrib but with a different color
-  nv.addDateAttrib = function (attr, _scale) {
-    const domain =
-      data !== undefined && data.length > 0
-        ? d3.extent(data, function (d) {
-            return getAttrib(d, attr);
-          })
-        : [0, 1];
-
-    const scale =
-      _scale ||
-      d3.scaleSequential(nv.defaultColorInterpolatorDate).domain(domain); //if we don"t have data, set the default domain
-    nv.addAttrib(attr, scale);
-
-    scale.__type = "date";
-    return nv;
-  };
-
-  // Adds a diverging scale
-  nv.addDivergingAttrib = function (attr, _scale) {
-    const domain =
-      data !== undefined && data.length > 0
-        ? d3.extent(data, function (d) {
-            return getAttrib(d, attr);
-          })
-        : [-1, 1];
-    const scale =
-      _scale ||
-      d3
-        .scaleSequential(nv.defaultColorInterpolatorDiverging)
-        .domain([domain[0], domain[1]]); //if we don"t have data, set the default domain
-    scale.__type = "div";
-    nv.addAttrib(attr, scale);
-    return nv;
-  };
-
-  /**
-   * A palette is either an array or a function of the category count. The count
-   * is not known when the column is added - scaleOrdinal builds its domain
-   * lazily - so a function palette is resolved later, in updateColorDomains,
-   * and remembered here until then.
-   */
-  function categoricalRange(n) {
-    const p = nv.defaultColorCategorical;
-    return typeof p === "function" ? p(n) : p;
-  }
-
-  nv.addCategoricalAttrib = function (attr, _scale) {
-    // 10 is a starting range only; updateColorDomains sets the real one once it
-    // knows how many categories there are.
-    const scale = _scale || d3.scaleOrdinal(categoricalRange(10));
-    // Who owns the colours. updateColorDomains re-resolves the palette for the
-    // scales Navio made and leaves a caller's scale alone.
-    scale.__navioOwned = !_scale;
-    scale.__type = "cat";
-    nv.addAttrib(attr, scale);
-
-    return nv;
-  };
-
-  nv.addTextAttrib = function (attr, _scale) {
-    const scale =
-      _scale ||
-      scaleText(
-        nv.nullColor,
-        nv.digitsForText,
-        nv.defaultColorInterpolatorText
-      );
-
-    nv.addAttrib(attr, scale);
-
-    return nv;
-  };
-
-  nv.addOrderedAttrib = function (attr, _scale) {
-    const scale =
-      _scale || scaleOrdered(nv.nullColor, nv.defaultColorInterpolatorOrdered);
-
-    nv.addAttrib(attr, scale);
-
-    return nv;
-  };
-
-  nv.addBooleanAttrib = function (attr, _scale) {
-    const scale =
-      _scale ||
-      d3
-        .scaleOrdinal()
-        .domain([true, false, null])
-        .range(nv.defaultColorRangeBoolean);
-
-    scale.__type = "bool";
-    nv.addAttrib(attr, scale);
-
-    return nv;
-  };
-
-  // Adds a more complex attribute with a wrapper to convert it into JSON
-  nv.addObjectAttrib = function (attr, _scale) {
-    const scale =
-      _scale ||
-      scaleText(
-        nv.nullColor,
-        nv.digitsForObjects, // nv.digitsForText,
-        nv.defaultColorInterpolatorObject
-      );
-
-    let stringifiedAttr;
-    if (typeof attr === "function") {
-      stringifiedAttr = (d) => JSON.stringify(attr(d));
-    } else {
-      stringifiedAttr = (d) => {
-        try {
-          return d[attr] ? JSON.stringify(d[attr]) : d[attr];
-        } catch (_e) {
-          return undefined;
-        }
-      };
-      // Navio derives a column's label from fn.name (see getAttribName), so
-      // set it directly rather than baking the attribute name into evaluated
-      // source the way convertAttribToFn still does - that pattern lets a
-      // crafted key in user-supplied data execute arbitrary code (see #71).
-      Object.defineProperty(stringifiedAttr, "name", { value: String(attr) });
-    }
-    nv.addAttrib(stringifiedAttr, scale);
-    return nv;
-  };
-
-  // Adds all the attributes on the data, or all the attributes provided on the list based on their types
-  nv.addAllAttribs = function (_attribs) {
-    if (!data || !data.length)
-      throw Error(
-        "addAllAttribs called without data to guess the attribs. Make sure to call it after setting the data"
-      );
-
-    let attribs =
-      _attribs !== undefined
-        ? _attribs
-        : getAttribsFromObjectAsFn(data[0], nv.addAllAttribsRecursionLevel);
-    // Attributes we skip are reported once at the end rather than one console
-    // line per column, so the message stays readable on wide datasets.
-    const skippedArrays = [],
-      skippedObjects = [];
-
-    for (let attr of attribs) {
-      if (attr === "__seqId" || attr === "__i" || attr === "selected") continue;
-
-      const attrName = typeof attr === "function" ? attr.name : attr;
-      const firstNotNull = findNotNull(data, attr);
-
-      if (
-        firstNotNull === null ||
-        firstNotNull === undefined ||
-        typeof firstNotNull === typeof ""
-      ) {
-        const numDistinctValues = new Set(
-          data
-            .slice(0, nv.howManyItemsShouldSearchForNotNull)
-            .map((d) => getAttrib(d, attr))
-        ).size;
-
-        // How many different elements are there
-        if (numDistinctValues < nv.maxNumDistinctForCategorical) {
-          nv.DEBUG &&
-            console.log(
-              `Navio: Adding attr ${attrName} as categorical with ${numDistinctValues} categories`
-            );
-          nv.addCategoricalAttrib(attr);
-        } else if (numDistinctValues < nv.maxNumDistinctForOrdered) {
-          nv.addOrderedAttrib(attr);
-          nv.DEBUG &&
-            console.log(
-              `Navio: Attr ${attrName} has more than ${nv.maxNumDistinctForCategorical} distinct values (${numDistinctValues}) using orderedAttrib`
-            );
-        } else {
-          nv.DEBUG &&
-            console.log(
-              `Navio: Attr ${attrName} has more than ${nv.maxNumDistinctForOrdered} distinct values (${numDistinctValues}) using textAttrib`
-            );
-          nv.addTextAttrib(attr);
-        }
-      } else if (typeof firstNotNull === typeof 0) {
-        // Numbers.
-        //
-        // Diverging only when the values actually STRADDLE the diverging point.
-        // updateColorDomains builds a diverging domain as [-absMax, absMax]
-        // around zero - "Assumes diverging point on 0" - so a column that never
-        // crosses zero gets a domain about twice its own magnitude with every
-        // value crammed into one end of the ramp. A negative minimum alone used
-        // to be enough, which is how citibike's start_lng (-74.02564 ..
-        // -73.886312) drew as one flat brown: its 0.139 of range sat inside a
-        // 148.05-wide domain, 0.094% of the scale.
-        const [numMin, numMax] = d3.extent(data, (d) => getAttrib(d, attr));
-        if (numMin < 0 && numMax > 0) {
-          nv.DEBUG &&
-            console.log(`Navio: Adding attr ${attrName} as diverging`);
-          nv.addDivergingAttrib(attr);
-        } else {
-          nv.DEBUG &&
-            console.log(`Navio: Adding attr ${attrName} as sequential`);
-          nv.addSequentialAttrib(attr);
-        }
-      } else if (firstNotNull instanceof Date) {
-        nv.DEBUG && console.log(`Navio: Adding attr ${attrName} as date`);
-        nv.addDateAttrib(attr);
-      } else if (typeof firstNotNull === typeof true) {
-        nv.DEBUG && console.log(`Navio: Adding attr ${attrName} as boolean`);
-        nv.addBooleanAttrib(attr);
-      } else {
-        // Default categories
-
-        if (Array.isArray(firstNotNull)) {
-          if (nv.addAllAttribsIncludeArrays) {
-            nv.DEBUG &&
-              console.log(
-                `Navio: Adding ${attrName} adding as Object (type=array)`
-              );
-            // nv.addCategoricalAttrib(attr);
-            nv.addObjectAttrib(attr);
-          } else {
-            skippedArrays.push(attrName);
-          }
-        } else {
-          if (nv.addAllAttribsIncludeObjects) {
-            nv.DEBUG &&
-              console.log(
-                `Navio: Adding object ${attrName} adding as Object (type=object)`
-              );
-            // nv.addCategoricalAttrib(attr);
-            nv.addObjectAttrib(attr);
-          } else {
-            skippedObjects.push(attrName);
-          }
-        }
-      }
-    }
-
-    // Skipping data silently would hide columns the caller expects to see, so
-    // this warns unconditionally - but only once, and it says how to opt in.
-    if (skippedArrays.length)
-      console.warn(
-        `navio.addAllAttribs: ignored ${skippedArrays.length} array attribute(s) [${skippedArrays.join(", ")}]. Set nv.addAllAttribsIncludeArrays = true to include them.`
-      );
-    if (skippedObjects.length)
-      console.warn(
-        `navio.addAllAttribs: ignored ${skippedObjects.length} object attribute(s) [${skippedObjects.join(", ")}]. Set nv.addAllAttribsIncludeObjects = true to include them.`
-      );
-
-    nv.data(data);
-    // drawBrushes(true); // updates brushes width
-    return nv;
-  };
+  // Declaring an attribute, guessing every column's type, and switching a
+  // column's type afterwards. Registers thirteen public methods on nv.
+  //
+  // All five bindings cross as getters: every one of them is REASSIGNED
+  // elsewhere in navio.js, so a captured value would leave the module reading
+  // a replaced array. The module never writes to any of them, which is why
+  // there are no setters here.
+  const _attribs = createAttribs({
+    nv,
+    get data() {
+      return data;
+    },
+    get attribsOrdered() {
+      return attribsOrdered;
+    },
+    get dAttribs() {
+      return dAttribs;
+    },
+    get colScales() {
+      return colScales;
+    },
+    attribAt,
+    getAttrib,
+    getAttribName,
+    moveAttrToPos,
+    findNotNull,
+  });
+  const { categoricalRange } = _attribs;
 
   nv.data = function (_) {
     initTooltipPopper();
@@ -4183,78 +3895,6 @@ function navio(selection, _h) {
   /** Is this attribute's column currently drawn? */
   nv.isAttribVisible = function (attrib) {
     return !hiddenAttribs.has(getAttribName(attrib));
-  };
-
-  // The attribute types a column can be switched between, and the method that
-  // builds each one's scale. "object" is excluded on purpose: addObjectAttrib
-  // replaces the attribute with a stringifying accessor rather than just
-  // changing its scale, so it is not a like-for-like swap.
-  const ATTRIB_TYPES = {
-    cat: { label: "categorical", add: "addCategoricalAttrib" },
-    seq: { label: "sequential", add: "addSequentialAttrib" },
-    ordered: { label: "ordered", add: "addOrderedAttrib" },
-    text: { label: "text", add: "addTextAttrib" },
-    date: { label: "date", add: "addDateAttrib" },
-    div: { label: "diverging", add: "addDivergingAttrib" },
-    bool: { label: "boolean", add: "addBooleanAttrib" },
-  };
-
-  /** The type tag of an attribute's colour scale: "cat", "seq", "text"... */
-  nv.getAttribType = function (attrib) {
-    const scale = colScales.get(attrib) || colScales.get(getAttribName(attrib));
-    return scale && scale.__type;
-  };
-
-  /** The switchable types, as {value, label} - for building a picker. */
-  nv.getAttribTypes = function () {
-    return Object.entries(ATTRIB_TYPES).map(([value, t]) => ({
-      value,
-      label: t.label,
-    }));
-  };
-
-  /**
-   * Re-type a column: how it is coloured and how its values are interpreted.
-   *
-   * Only the colour scale changes. The attribute keeps its name, its position,
-   * and anything pointing at it - sorting compares raw values and so does a
-   * value filter, while a range filter compares positions, so none of them are
-   * invalidated by a re-type. addAllAttribs guesses types from the data and
-   * sometimes guesses wrong; this is the correction.
-   */
-  nv.setAttribType = function (attrib, type) {
-    const spec = ATTRIB_TYPES[type];
-    if (!spec) {
-      console.warn(
-        `navio.setAttribType: unknown type "${type}". ` +
-          `One of: ${Object.keys(ATTRIB_TYPES).join(", ")}`
-      );
-      return nv;
-    }
-    const name = getAttribName(attrib);
-    const pos = attribsOrdered.findIndex((a) => getAttribName(a) === name);
-    if (pos === -1) {
-      console.warn(
-        `navio.setAttribType: "${name}" is not one of the attributes`
-      );
-      return nv;
-    }
-    const attr = attribsOrdered[pos];
-    if (nv.getAttribType(attr) === type) return nv;
-
-    // Drop it from all three structures and let the real add*Attrib rebuild
-    // it, so the scale is constructed exactly as it would have been at setup -
-    // domain included. Then put it back where it was: addAttrib appends.
-    attribsOrdered.splice(pos, 1);
-    dAttribs.delete(name);
-    colScales.delete(attr);
-    colScales.delete(name);
-
-    nv[spec.add](attr);
-    moveAttrToPos(attr, pos);
-
-    nv.hardUpdate();
-    return nv;
   };
 
   /** The attributes currently drawn, in order. A subset of getAttribs(). */


### PR DESCRIPTION
## What changed

`src/attribs.js` (426 lines, new) — how a column becomes an attribute: declaring
one with a scale, guessing the type of every column in the data, and switching a
column's type afterwards. It registers thirteen public methods on `nv`:
`addAttrib`, the eight `add*Attrib` variants, `addAllAttribs`, `getAttribType`,
`getAttribTypes`, `setAttribType`.

`src/navio.js`: **4,545 → 4,185**.

Second slice of #67, following the mechanism established in #107.

## Why

Chosen by re-measuring every remaining candidate with the corrected method from
`docs/ai/2026-08-20-navio-decomposition-design.md` §9 — comments and string
literals stripped line-count-preservingly, reference sites counted rather than
assignment sites, `const`-declared functions included — not by taking the next
region down the file.

| Candidate | Lines | Exports | State | Calls out | Lines per unit of interface |
| --- | ---: | ---: | ---: | ---: | ---: |
| **attribs: define + type** | 375 | 1 | 5 | 5 | **34** |
| header band + labels | 248 | 2 | 6 | 7 | 17 |
| colour domains + scales | 277 | 2 | 9 | 7 | 15 |
| tooltip (scattered) | 318 | 4 | 16 | 4 | 13 |
| drag/drop columns | 126 | 4 | 9 | 5 | 7 |

It is also the cleanest contract of the three modules extracted so far: the
module is **read-only** over the closure — it never writes to any binding it is
given — so its context is all getters and no setters.

All five bindings it reads (`data`, `attribsOrdered`, `dAttribs`, `colScales`,
`nv`) are reassigned elsewhere in `navio.js`, so every one has to cross as a
getter or the module would go on reading a replaced array.

## How it was verified

`npm run check` and the full Playwright suite, both green: **102 unit tests, 291
e2e**. `docs/ai/API.md` unchanged and `test/e2e/104-describe.spec.js` green,
which is what proves the thirteen public methods kept their names and did not
leak into `OPTION_NAMES`.

No new tests. This slice introduces no new mechanism — the live-binding contract
is already pinned by `test/e2e/67-extraction.spec.js` from #107, and the
attribute behaviour is covered by the existing suite.

## Risk and rollback

Behaviour-preserving by intent. Two defects the mechanical rewrite produced,
both caught before running:

- `${nv.maxNumDistinctForCategorical}` and `${getAttribName(attr)}` are real code
  inside template literals, which the rewriter masks so it cannot corrupt
  generated output. **That masking hid live references for the second time in
  this refactor**, so the masker is fixed rather than the symptom: it now masks
  only the literal chunks of a template and leaves every `${...}` as code.
- The type block's range ran one line short and would have left a dangling `};`
  in `navio.js`.

Rollback is a `git revert` of the single commit.

## Note on what remains

`navio.js` is 4,185 lines against a ~800-line goal, and the measured ratio has
dropped from 48 (the settings slice in #107) to 34 here to **17** for everything
left. Continuing one topic at a time will not reach the goal — see the comment on
#67.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AvHvCduwZnafTSRD6N8hH6
